### PR TITLE
Add comprehensive type check results

### DIFF
--- a/type-check-results.md
+++ b/type-check-results.md
@@ -1,0 +1,2287 @@
+mind-agents/src/core/enhanced-event-bus.ts(8,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/core/enhanced-event-bus.ts(9,32): error TS2307: Cannot find module 'fs' or its corresponding type declarations.
+mind-agents/src/core/enhanced-event-bus.ts(10,22): error TS2307: Cannot find module 'path' or its corresponding type declarations.
+mind-agents/src/core/enhanced-event-bus.ts(112,24): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/core/enhanced-event-bus.ts(143,10): error TS2339: Property 'setMaxListeners' does not exist on type 'SYMindXEnhancedEventBus'.
+mind-agents/src/core/enhanced-event-bus.ts(330,10): error TS2339: Property 'removeAllListeners' does not exist on type 'SYMindXEnhancedEventBus'.
+mind-agents/src/core/enhanced-event-bus.ts(422,23): error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/enhanced-event-bus.ts(450,50): error TS7006: Parameter 'line' implicitly has an 'any' type.
+mind-agents/src/core/enhanced-event-bus.ts(538,50): error TS7006: Parameter 'line' implicitly has an 'any' type.
+mind-agents/src/core/enhanced-event-bus.ts(590,27): error TS7006: Parameter 'file' implicitly has an 'any' type.
+mind-agents/src/core/runtime.ts(26,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/core/runtime.ts(33,23): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/core/runtime.ts(47,31): error TS2307: Cannot find module 'fs/promises' or its corresponding type declarations.
+mind-agents/src/core/runtime.ts(48,33): error TS2307: Cannot find module 'path' or its corresponding type declarations.
+mind-agents/src/core/runtime.ts(89,21): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/core/runtime.ts(153,31): error TS2307: Cannot find module 'fs/promises' or its corresponding type declarations.
+mind-agents/src/core/runtime.ts(154,33): error TS2307: Cannot find module 'path' or its corresponding type declarations.
+mind-agents/src/core/runtime.ts(166,40): error TS7006: Parameter 'file' implicitly has an 'any' type.
+mind-agents/src/core/runtime.ts(189,21): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/core/runtime.ts(531,11): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(531,42): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(535,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(536,28): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(537,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(538,25): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(539,28): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(540,39): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(546,11): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(550,34): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(551,24): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(552,31): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(552,83): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(553,27): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(553,75): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(559,11): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(559,43): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(563,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(564,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(565,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(566,28): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(566,76): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(567,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/core/runtime.ts(567,78): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/index.ts(8,67): error TS2307: Cannot find module 'express' or its corresponding type declarations.
+mind-agents/src/extensions/api/index.ts(9,18): error TS2307: Cannot find module 'http' or its corresponding type declarations.
+mind-agents/src/extensions/api/index.ts(10,44): error TS2307: Cannot find module 'ws' or its corresponding type declarations.
+mind-agents/src/extensions/api/index.ts(11,30): error TS2307: Cannot find module 'uuid' or its corresponding type declarations.
+mind-agents/src/extensions/api/index.ts(36,3): error TS2300: Duplicate identifier 'actions'.
+mind-agents/src/extensions/api/index.ts(37,3): error TS2300: Duplicate identifier 'events'.
+mind-agents/src/extensions/api/index.ts(165,47): error TS7006: Parameter 'req' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(189,25): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(203,23): error TS7006: Parameter 'error' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(280,19): error TS7006: Parameter 'req' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(280,24): error TS7006: Parameter 'res' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(280,29): error TS7006: Parameter 'next' implicitly has an 'any' type.
+mind-agents/src/extensions/api/index.ts(373,21): error TS2532: Object is possibly 'undefined'.
+mind-agents/src/extensions/api/index.ts(433,41): error TS2551: Property 'getIntensity' does not exist on type 'EmotionModule'. Did you mean 'intensity'?
+mind-agents/src/extensions/api/index.ts(467,33): error TS2554: Expected 2 arguments, but got 1.
+mind-agents/src/extensions/api/index.ts(489,61): error TS2345: Argument of type '{ role: "user"; content: string; }[]' is not assignable to parameter of type 'ChatMessage[]'.
+  Type '{ role: "user"; content: string; }' is not assignable to type 'ChatMessage'.
+    Types of property 'role' are incompatible.
+      Type '"user"' is not assignable to type 'MessageRole'.
+mind-agents/src/extensions/api/index.ts(496,33): error TS2554: Expected 2 arguments, but got 1.
+mind-agents/src/extensions/api/index.ts(498,29): error TS2339: Property 'content' does not exist on type 'ChatGenerationResult'.
+mind-agents/src/extensions/api/index.ts(514,28): error TS2339: Property 'content' does not exist on type 'ChatGenerationResult'.
+mind-agents/src/extensions/api/index.ts(569,51): error TS2345: Argument of type '{ role: "user"; content: string; }[]' is not assignable to parameter of type 'ChatMessage[]'.
+  Type '{ role: "user"; content: string; }' is not assignable to type 'ChatMessage'.
+    Types of property 'role' are incompatible.
+      Type '"user"' is not assignable to type 'MessageRole'.
+mind-agents/src/extensions/api/index.ts(749,7): error TS2300: Duplicate identifier 'actions'.
+mind-agents/src/extensions/api/index.ts(803,7): error TS2300: Duplicate identifier 'events'.
+mind-agents/src/extensions/api/skills/authentication.ts(9,25): error TS2307: Cannot find module 'express' or its corresponding type declarations.
+mind-agents/src/extensions/api/skills/authentication.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { token: string; type: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/authentication.ts(32,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { apiKey: string; permissions: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/authentication.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { userId: string; action: string; resource: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/authentication.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { userId: string; metadata: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/authentication.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: string; reason: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/authentication.ts(79,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(96,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/authentication.ts(110,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(130,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(147,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/authentication.ts(159,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(183,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/authentication.ts(198,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(232,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/authentication.ts(244,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/authentication.ts(272,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/authentication.ts(284,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(15,16): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(44,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { includeMetrics: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(53,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { timeRange: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(62,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { endpoint: string; method: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(71,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { endpoint: string; responseTime: string; success: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(80,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(89,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { confirm: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(98,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { metric: string; threshold: string; operator: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(150,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(159,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(178,27): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(196,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(214,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(268,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(281,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(333,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(347,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(363,27): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(364,24): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(365,22): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(369,20): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(370,21): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(371,17): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(386,16): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(387,17): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(396,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(404,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(424,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(451,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(463,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(489,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(501,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(514,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/health-monitoring.ts(530,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/http.ts(9,35): error TS2307: Cannot find module 'express' or its corresponding type declarations.
+mind-agents/src/extensions/api/skills/http.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { message: string; sessionId: string; userId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/http.ts(32,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { response: string; statusCode: string; headers: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/http.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { request: string; schema: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/http.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { origin: string; methods: string; headers: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/http.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { clientId: string; endpoint: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/http.ts(78,36): error TS2339: Property 'processMessage' does not exist on type 'Agent'.
+mind-agents/src/extensions/api/skills/http.ts(87,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/http.ts(100,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/http.ts(124,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/http.ts(137,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/http.ts(161,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/http.ts(173,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/http.ts(201,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/http.ts(212,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/http.ts(236,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/http.ts(250,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { userId: string; metadata: string; ttl: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(32,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: string; data: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: string; extensionTime: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: string; reason: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(68,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { userId: string; includeExpired: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(77,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/session-management.ts(115,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(127,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(149,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(166,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(181,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(203,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(227,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(238,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(260,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(286,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(299,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(321,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(337,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(351,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(385,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(398,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/session-management.ts(427,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/session-management.ts(440,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(9,27): error TS2307: Cannot find module 'ws' or its corresponding type declarations.
+mind-agents/src/extensions/api/skills/websocket.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { message: string; type: string; data: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(32,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { clientId: string; message: string; type: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { clientId: string; message: string; type: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { action: string; clientId: string; metadata: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { thought: string; emotion: string; context: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(68,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { status: string; data: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/api/skills/websocket.ts(100,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(113,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(141,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(155,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(177,34): error TS2339: Property 'processMessage' does not exist on type 'Agent'.
+mind-agents/src/extensions/api/skills/websocket.ts(189,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(203,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(239,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(253,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(289,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(301,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/skills/websocket.ts(336,9): error TS2353: Object literal may only specify known properties, and 'data' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/api/skills/websocket.ts(348,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/api/types.ts(7,35): error TS2307: Cannot find module 'express' or its corresponding type declarations.
+mind-agents/src/extensions/index.ts(21,25): error TS2339: Property 'slack' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(22,65): error TS2339: Property 'slack' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(23,21): error TS2345: Argument of type 'SlackExtension' is not assignable to parameter of type 'Extension'.
+  Type 'SlackExtension' is missing the following properties from type 'Extension': type, status
+mind-agents/src/extensions/index.ts(28,25): error TS2339: Property 'runelite' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(29,71): error TS2339: Property 'runelite' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(30,21): error TS2345: Argument of type 'RuneLiteExtension' is not assignable to parameter of type 'Extension'.
+  Type 'RuneLiteExtension' is missing the following properties from type 'Extension': type, status
+mind-agents/src/extensions/index.ts(35,25): error TS2339: Property 'twitter' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(36,69): error TS2339: Property 'twitter' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(37,21): error TS2345: Argument of type 'TwitterExtension' is not assignable to parameter of type 'Extension'.
+  Type 'TwitterExtension' is missing the following properties from type 'Extension': type, status
+mind-agents/src/extensions/index.ts(42,26): error TS2339: Property 'mcp' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(43,61): error TS2339: Property 'mcp' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(44,21): error TS2345: Argument of type 'McpExtension' is not assignable to parameter of type 'Extension'.
+  Type 'McpExtension' is missing the following properties from type 'Extension': type, status
+mind-agents/src/extensions/index.ts(49,26): error TS2339: Property 'mcpClient' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(50,73): error TS2339: Property 'mcpClient' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(51,21): error TS2345: Argument of type 'McpClientExtension' is not assignable to parameter of type 'Extension'.
+  Type 'McpClientExtension' is missing the following properties from type 'Extension': id, enabled, tick
+mind-agents/src/extensions/index.ts(56,26): error TS2339: Property 'api' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/index.ts(57,61): error TS2339: Property 'api' does not exist on type '{ autoLoad: boolean; paths: string[]; }'.
+mind-agents/src/extensions/mcp-client/index.ts(3,24): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/index' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/index.ts(4,38): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/stdio' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/index.ts(5,36): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/sse' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/index.ts(6,37): error TS2307: Cannot find module 'child_process' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/index.ts(22,14): error TS2420: Class 'McpClientExtension' incorrectly implements interface 'EnhancedExtension'.
+  Type 'McpClientExtension' is missing the following properties from type 'EnhancedExtension': dependencies, hotReload
+mind-agents/src/extensions/mcp-client/index.ts(22,14): error TS2420: Class 'McpClientExtension' incorrectly implements interface 'Extension'.
+  Type 'McpClientExtension' is missing the following properties from type 'Extension': id, enabled, tick
+mind-agents/src/extensions/mcp-client/index.ts(24,24): error TS2339: Property 'INTEGRATION' does not exist on type 'typeof ExtensionType'.
+mind-agents/src/extensions/mcp-client/index.ts(28,29): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(77,40): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp-client/index.ts(79,11): error TS2564: Property 'skills' has no initializer and is not definitely assigned in the constructor.
+mind-agents/src/extensions/mcp-client/index.ts(155,11): error TS2367: This comparison appears to be unintentional because the types 'McpTransportConfig' and 'string' have no overlap.
+mind-agents/src/extensions/mcp-client/index.ts(157,38): error TS2339: Property 'command' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(157,60): error TS2339: Property 'args' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(159,50): error TS2339: Property 'env' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(165,30): error TS7006: Parameter 'error' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/index.ts(170,29): error TS7006: Parameter 'code' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/index.ts(170,35): error TS7006: Parameter 'signal' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/index.ts(175,27): error TS2339: Property 'reconnect' does not exist on type 'McpClientConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(181,33): error TS2339: Property 'command' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(182,30): error TS2339: Property 'args' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(183,29): error TS2339: Property 'env' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(185,18): error TS2367: This comparison appears to be unintentional because the types 'McpTransportConfig' and 'string' have no overlap.
+mind-agents/src/extensions/mcp-client/index.ts(186,65): error TS2339: Property 'url' does not exist on type 'McpServerConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(213,9): error TS2353: Object literal may only specify known properties, and 'process' does not exist in type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(232,7): error TS2532: Object is possibly 'undefined'.
+mind-agents/src/extensions/mcp-client/index.ts(232,52): error TS2554: Expected 1 arguments, but got 2.
+mind-agents/src/extensions/mcp-client/index.ts(249,41): error TS2339: Property 'reconnect' does not exist on type 'McpClientConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(296,38): error TS2339: Property 'reconnect' does not exist on type 'McpClientConfig'.
+mind-agents/src/extensions/mcp-client/index.ts(316,9): error TS2532: Object is possibly 'undefined'.
+mind-agents/src/extensions/mcp-client/index.ts(316,57): error TS2554: Expected 1 arguments, but got 2.
+mind-agents/src/extensions/mcp-client/index.ts(333,5): error TS2532: Object is possibly 'undefined'.
+mind-agents/src/extensions/mcp-client/index.ts(333,49): error TS2554: Expected 1 arguments, but got 2.
+mind-agents/src/extensions/mcp-client/index.ts(358,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(364,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(365,38): error TS2352: Conversion of type 'SkillParameters' to type 'McpToolCall' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'SkillParameters' is missing the following properties from type 'McpToolCall': serverId, toolName, arguments
+mind-agents/src/extensions/mcp-client/index.ts(371,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(376,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(377,41): error TS2352: Conversion of type 'SkillParameters' to type 'McpResourceRequest' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'SkillParameters' is missing the following properties from type 'McpResourceRequest': serverId, resourceUri
+mind-agents/src/extensions/mcp-client/index.ts(383,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(389,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(390,39): error TS2352: Conversion of type 'SkillParameters' to type 'McpPromptRequest' may be a mistake because neither type sufficiently overlaps with the other. If this was intentional, convert the expression to 'unknown' first.
+  Type 'SkillParameters' is missing the following properties from type 'McpPromptRequest': serverId, promptName
+mind-agents/src/extensions/mcp-client/index.ts(396,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(398,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(405,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(409,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(416,34): error TS2551: Property 'INTEGRATION' does not exist on type 'typeof ActionCategory'. Did you mean 'INTERACTION'?
+mind-agents/src/extensions/mcp-client/index.ts(420,9): error TS2353: Object literal may only specify known properties, and 'handler' does not exist in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/index.ts(425,15): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(430,38): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(431,15): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(447,7): error TS2322: Type '(data: GenericData) => Promise<void>' is not assignable to type '(agent: Agent, event: AgentEvent) => Promise<void>'.
+  Types of parameters 'data' and 'agent' are incompatible.
+    Type 'Agent' is not assignable to type 'GenericData'.
+      Index signature for type 'string' is missing in type 'Agent'.
+mind-agents/src/extensions/mcp-client/index.ts(454,7): error TS2322: Type '(data: GenericData) => Promise<void>' is not assignable to type '(agent: Agent, event: AgentEvent) => Promise<void>'.
+  Types of parameters 'data' and 'agent' are incompatible.
+    Type 'Agent' is not assignable to type 'GenericData'.
+      Index signature for type 'string' is missing in type 'Agent'.
+mind-agents/src/extensions/mcp-client/index.ts(463,55): error TS2339: Property 'serverName' does not exist on type 'McpToolCall'.
+mind-agents/src/extensions/mcp-client/index.ts(466,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(467,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(467,53): error TS2339: Property 'serverName' does not exist on type 'McpToolCall'.
+mind-agents/src/extensions/mcp-client/index.ts(472,27): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(474,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(475,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(475,57): error TS2339: Property 'serverName' does not exist on type 'McpToolCall'.
+mind-agents/src/extensions/mcp-client/index.ts(481,22): error TS2339: Property 'lastActivity' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(489,7): error TS2532: Object is possibly 'undefined'.
+mind-agents/src/extensions/mcp-client/index.ts(489,50): error TS2554: Expected 1 arguments, but got 2.
+mind-agents/src/extensions/mcp-client/index.ts(490,29): error TS2339: Property 'serverName' does not exist on type 'McpToolCall'.
+mind-agents/src/extensions/mcp-client/index.ts(500,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(505,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(506,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(514,55): error TS2339: Property 'serverName' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(517,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(518,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(518,53): error TS2339: Property 'serverName' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(523,27): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(525,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(526,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(526,57): error TS2339: Property 'serverName' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(532,22): error TS2339: Property 'lastActivity' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(534,78): error TS2339: Property 'uri' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(538,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(538,62): error TS2339: Property 'uri' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(543,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(544,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(544,53): error TS2339: Property 'uri' does not exist on type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(552,55): error TS2339: Property 'serverName' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(555,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(556,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(556,53): error TS2339: Property 'serverName' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(561,27): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(563,34): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(564,11): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(564,57): error TS2339: Property 'serverName' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(570,22): error TS2339: Property 'lastActivity' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(573,23): error TS2339: Property 'name' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(579,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(579,60): error TS2339: Property 'name' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(584,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(585,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(585,51): error TS2339: Property 'name' does not exist on type 'McpPromptRequest'.
+mind-agents/src/extensions/mcp-client/index.ts(597,35): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(598,9): error TS2353: Object literal may only specify known properties, and 'transport' does not exist in type 'McpServerStatus'.
+mind-agents/src/extensions/mcp-client/index.ts(598,35): error TS2339: Property 'config' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(604,38): error TS2339: Property 'lastActivity' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(610,7): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(619,32): error TS2339: Property 'ERROR' does not exist on type 'typeof ActionResultType'.
+mind-agents/src/extensions/mcp-client/index.ts(620,9): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(627,33): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(628,7): error TS2353: Object literal may only specify known properties, and 'transport' does not exist in type 'McpServerStatus'.
+mind-agents/src/extensions/mcp-client/index.ts(628,33): error TS2339: Property 'config' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(634,36): error TS2339: Property 'lastActivity' does not exist on type 'McpClientInstance'.
+mind-agents/src/extensions/mcp-client/index.ts(642,7): error TS2353: Object literal may only specify known properties, and 'message' does not exist in type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/index.ts(652,26): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(667,26): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/index.ts(682,26): error TS2551: Property 'connected' does not exist on type 'McpClientInstance'. Did you mean 'isConnected'?
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; config: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; graceful: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(57,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(69,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { includeInactive: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(81,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; timeout: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(98,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; timeout: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(115,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; config: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(132,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; timeRange: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(149,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; clearCache: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(166,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; timeout: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(200,43): error TS2341: Property 'connectToServer' is private and only accessible within class 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(200,69): error TS2554: Expected 1 arguments, but got 2.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(207,32): error TS2339: Property 'connectionId' does not exist on type 'void'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(208,30): error TS2339: Property 'serverInfo' does not exist on type 'void'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(209,32): error TS2339: Property 'capabilities' does not exist on type 'void'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(235,28): error TS2339: Property 'disconnectFromServer' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(262,39): error TS2339: Property 'getConnectionStatus' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(284,44): error TS2339: Property 'getAllConnectionStatuses' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(291,23): error TS18046: 'status' is of type 'unknown'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(292,26): error TS18046: 'status' is of type 'unknown'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(293,29): error TS18046: 'status' is of type 'unknown'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(294,31): error TS18046: 'status' is of type 'unknown'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(297,70): error TS18046: 's' is of type 'unknown'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(316,42): error TS2339: Property 'listConnections' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(321,40): error TS7006: Parameter 'conn' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(340,38): error TS7006: Parameter 'c' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(341,40): error TS7006: Parameter 'c' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(366,43): error TS2339: Property 'reconnectToServer' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(402,43): error TS2339: Property 'testConnection' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(438,28): error TS2339: Property 'configureConnection' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(464,38): error TS2339: Property 'getConnectionMetrics' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(511,28): error TS2339: Property 'resetConnection' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/client-connection.ts(551,28): error TS2339: Property 'setConnectionTimeout' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; resourceType: { type: string; description: string; required: false; }; search: { type: string; description: string; required: false; }; mimeType: { ...; }; }; execute: (agent: Agent, params: any) => ...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; format: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(72,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(89,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; callback: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(111,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(128,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { query: { type: string; description: string; required: true; }; serverId: { type: string; description: string; required: false; }; resourceType: { type: string; description: string; required: false; }; mimeType: { ...; }; limit: { ...; }; }; execute: (agent: Agent, p...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(160,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; localPath: { type: string; description: string; required: true; }; overwrite: { ...; }; }; execute: (agent: Agent, params: any) => ...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(187,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { requests: { type: string; description: string; required: true; }; parallel: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(204,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(216,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; resourceUri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(243,46): error TS2339: Property 'listResources' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(253,36): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(270,46): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(271,52): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(272,48): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(298,45): error TS2341: Property 'getResource' is private and only accessible within class 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(301,9): error TS2353: Object literal may only specify known properties, and 'format' does not exist in type 'McpResourceRequest'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(307,25): error TS2339: Property 'uri' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(308,26): error TS2339: Property 'name' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(309,33): error TS2339: Property 'description' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(310,30): error TS2339: Property 'mimeType' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(311,29): error TS2339: Property 'content' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(312,28): error TS2339: Property 'format' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(313,26): error TS2339: Property 'size' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(314,30): error TS2339: Property 'encoding' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(315,34): error TS2339: Property 'lastModified' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(316,29): error TS2339: Property 'version' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(317,30): error TS2339: Property 'checksum' does not exist on type 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(345,41): error TS2339: Property 'getResourceInfo' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(401,49): error TS2339: Property 'subscribeToResource' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(441,28): error TS2339: Property 'unsubscribeFromResource' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(477,44): error TS2339: Property 'searchResources' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(488,44): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(533,43): error TS2339: Property 'downloadResource' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(576,44): error TS2339: Property 'batchGetResources' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(585,40): error TS7006: Parameter 'result' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(601,48): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(602,44): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(624,46): error TS2339: Property 'getResourceTemplates' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(629,36): error TS7006: Parameter 'template' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(635,50): error TS7006: Parameter 'param' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(648,46): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(649,52): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/resource-retrieval.ts(674,47): error TS2339: Property 'validateResourceUri' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { network: { type: string; description: string; required: false; }; timeout: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverConfig: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(52,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(64,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { includeOffline: { type: string; description: string; required: false; }; category: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(81,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; includeCapabilities: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(98,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { subnet: { type: string; description: string; required: false; }; ports: { type: string; description: string; required: false; }; timeout: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(120,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverConfig: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(132,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { source: { type: string; description: string; required: true; }; format: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(149,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; destination: { type: string; description: string; required: true; }; format: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(171,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; config: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(198,54): error TS2339: Property 'discoverServers' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(206,42): error TS7006: Parameter 'server' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(256,43): error TS2339: Property 'registerServer' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(290,28): error TS2339: Property 'unregisterServer' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(316,38): error TS2339: Property 'getRegisteredServers' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(324,32): error TS7006: Parameter 'server' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(340,34): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(341,35): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(342,47): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(368,47): error TS2339: Property 'getServerInfo' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(401,40): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(406,48): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(412,44): error TS7006: Parameter 'prompt' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(439,48): error TS2339: Property 'scanNetwork' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(448,40): error TS7006: Parameter 'host' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(451,35): error TS7006: Parameter 'port' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(459,50): error TS7006: Parameter 'server' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(497,47): error TS2339: Property 'validateServerConfig' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(538,43): error TS2339: Property 'importServerConfig' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(575,43): error TS2339: Property 'exportServerConfig' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/server-discovery.ts(616,43): error TS2339: Property 'updateServerConfig' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; sessionConfig: { type: string; description: string; required: false; }; persistent: { ...; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(45,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; includeMetrics: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(62,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; status: { type: string; description: string; required: false; }; includeInactive: { ...; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(84,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; config: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(101,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; duration: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(118,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; reason: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(135,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: false; }; serverId: { type: string; description: string; required: false; }; timeRange: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(157,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; maxAge: { type: string; description: string; required: false; }; force: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(179,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; stateName: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(196,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { sessionId: { type: string; description: string; required: true; }; stateName: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(230,44): error TS2339: Property 'createSession' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(272,44): error TS2339: Property 'getSession' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(328,45): error TS2339: Property 'listSessions' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(337,34): error TS7006: Parameter 'session' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(351,35): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(352,37): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(353,36): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(354,45): error TS7006: Parameter 's' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(380,43): error TS2339: Property 'updateSession' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(416,43): error TS2339: Property 'extendSession' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(451,43): error TS2339: Property 'closeSession' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(484,44): error TS2339: Property 'getSessionMetrics' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(549,43): error TS2339: Property 'cleanupSessions' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(590,43): error TS2339: Property 'saveSessionState' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/session-management.ts(629,43): error TS2339: Property 'restoreSessionState' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; toolName: { type: string; description: string; required: true; }; arguments: { type: string; description: string; required: false; }; timeout: { ...; }; }; execute: (agent: Agent, params: any) => Prom...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; category: { type: string; description: string; required: false; }; search: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(72,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; toolName: { type: string; description: string; required: true; }; includeSchema: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResul...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(94,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; toolName: { type: string; description: string; required: true; }; arguments: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(116,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { invocations: { type: string; description: string; required: true; }; parallel: { type: string; description: string; required: false; }; stopOnError: { ...; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(138,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: false; }; toolName: { type: string; description: string; required: false; }; limit: { type: string; description: string; required: false; }; since: { ...; }; }; execute: (agent: Agent, params: any) => Promise<...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(165,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { invocationId: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(177,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { invocationId: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(189,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { serverId: { type: string; description: string; required: true; }; toolName: { type: string; description: string; required: true; }; alias: { type: string; description: string; required: true; }; defaultArguments: { ...; }; }; execute: (agent: Agent, params: any) => ...' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(216,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { alias: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(245,43): error TS2339: Property 'invokeTool' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(284,42): error TS2339: Property 'listTools' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(293,28): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(313,42): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(314,45): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(340,45): error TS2339: Property 'getToolInfo' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(364,44): error TS7006: Parameter 'example' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(403,47): error TS2339: Property 'validateToolArguments' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(446,44): error TS2339: Property 'batchInvokeTools' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(456,40): error TS7006: Parameter 'result' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(468,48): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(469,44): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(493,44): error TS2339: Property 'getInvocationHistory' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(503,48): error TS7006: Parameter 'inv' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(552,43): error TS2339: Property 'cancelInvocation' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(586,43): error TS2339: Property 'getInvocationStatus' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(633,28): error TS2339: Property 'createToolAlias' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/skills/tool-invocation.ts(673,28): error TS2339: Property 'removeToolAlias' does not exist on type 'McpClientExtension'.
+mind-agents/src/extensions/mcp-client/types.ts(7,24): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/index' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/types.ts(8,38): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/stdio' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/types.ts(9,36): error TS2307: Cannot find module '@modelcontextprotocol/sdk/client/sse' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/types.ts(10,45): error TS2307: Cannot find module '@modelcontextprotocol/sdk/types' or its corresponding type declarations.
+mind-agents/src/extensions/mcp-client/types.ts(359,10): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp-client/types.ts(360,11): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp-client/types.ts(361,11): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp-client/types.ts(362,17): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp/index.ts(10,27): error TS2307: Cannot find module '@modelcontextprotocol/sdk/server/mcp.js' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/index.ts(11,38): error TS2307: Cannot find module '@modelcontextprotocol/sdk/server/stdio.js' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/index.ts(19,8): error TS2307: Cannot find module '@modelcontextprotocol/sdk/types.js' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/index.ts(20,19): error TS2307: Cannot find module 'zod' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/index.ts(36,3): error TS2416: Property 'config' in type 'McpExtension' is not assignable to the same property in base type 'Extension'.
+  Property 'settings' is missing in type 'McpConfig' but required in type 'ExtensionConfig'.
+mind-agents/src/extensions/mcp/index.ts(47,7): error TS2783: 'enabled' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(48,7): error TS2783: 'serverName' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(49,7): error TS2783: 'serverVersion' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(50,7): error TS2783: 'transport' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(51,7): error TS2783: 'tools' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(52,7): error TS2783: 'resources' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(53,7): error TS2783: 'prompts' is specified more than once, so this usage will be overwritten.
+mind-agents/src/extensions/mcp/index.ts(75,7): error TS2740: Type 'Record<string, any>' is missing the following properties from type 'any[]': length, pop, push, concat, and 29 more.
+mind-agents/src/extensions/mcp/index.ts(134,16): error TS7031: Binding element 'include_memory' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(134,32): error TS7031: Binding element 'include_emotion' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(147,16): error TS7031: Binding element 'query' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(147,23): error TS7031: Binding element 'limit' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(160,16): error TS7031: Binding element 'message' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(160,25): error TS7031: Binding element 'context' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(174,16): error TS7031: Binding element 'extension' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(174,27): error TS7031: Binding element 'action' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(174,35): error TS7031: Binding element 'parameters' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(188,18): error TS7006: Parameter 'params' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(210,64): error TS7006: Parameter 'request' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(240,61): error TS7006: Parameter 'request' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/index.ts(277,39): error TS2551: Property 'getIntensity' does not exist on type 'EmotionModule'. Did you mean 'intensity'?
+mind-agents/src/extensions/mcp/index.ts(303,71): error TS2345: Argument of type 'number' is not assignable to parameter of type 'number[]'.
+mind-agents/src/extensions/mcp/index.ts(336,61): error TS2345: Argument of type '{ role: "user"; content: string; }[]' is not assignable to parameter of type 'ChatMessage[]'.
+  Type '{ role: "user"; content: string; }' is not assignable to type 'ChatMessage'.
+    Types of property 'role' are incompatible.
+      Type '"user"' is not assignable to type 'MessageRole'.
+mind-agents/src/extensions/mcp/index.ts(341,26): error TS2339: Property 'content' does not exist on type 'ChatGenerationResult'.
+mind-agents/src/extensions/mcp/index.ts(433,39): error TS2322: Type 'string' is not assignable to type 'GenericData'.
+mind-agents/src/extensions/mcp/index.ts(435,37): error TS2322: Type 'string' is not assignable to type 'GenericData'.
+mind-agents/src/extensions/mcp/index.ts(437,13): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/mcp/index.ts(446,11): error TS2741: Property 'type' is missing in type '{ success: true; result: { enabled: boolean; running: boolean; serverName: string; toolsCount: number; resourcesCount: number; promptsCount: number; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/mcp/index.ts(461,5): error TS2322: Type '{ startMcpServer: { name: string; description: string; parameters: {}; execute: (agent: Agent, params: SkillParameters) => Promise<ActionResult>; }; getMcpStatus: { name: string; description: string; parameters: {}; execute: (agent: Agent, params: SkillParameters) => Promise<ActionResult>; }; }' is not assignable to type 'Record<string, ExtensionAction>'.
+  Property 'startMcpServer' is incompatible with index signature.
+    Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: SkillParameters) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(13,33): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(25,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { detailed: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(37,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { interval: { type: string; description: string; required: false; }; alertThreshold: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(54,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(60,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { timeout: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(72,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { timeRange: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(84,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { connectionId: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(96,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { timeout: { type: string; description: string; required: false; }; payload: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(113,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { level: { type: string; description: string; required: false; }; limit: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(130,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(136,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { config: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(159,39): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(160,36): error TS2339: Property 'getServerPort' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(161,32): error TS2339: Property 'getUptime' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(162,37): error TS2339: Property 'getActiveConnections' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(163,38): error TS2339: Property 'getLastActivity' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(164,32): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(170,38): error TS2339: Property 'getServerInfo' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(171,40): error TS2339: Property 'getCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(172,41): error TS2339: Property 'getConfiguration' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(174,26): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(175,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(176,28): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(177,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(342,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(350,43): error TS2339: Property 'testConnection' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(378,33): error TS2339: Property 'getConnectionLogs' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(382,28): error TS7006: Parameter 'log' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(393,26): error TS7006: Parameter 'log' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(418,22): error TS2339: Property 'resetMetrics' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(449,22): error TS2339: Property 'setAlertConfiguration' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(473,37): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(474,30): error TS2339: Property 'getUptime' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(475,35): error TS2339: Property 'getActiveConnections' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(502,49): error TS2339: Property 'testConnection' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(605,42): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(618,40): error TS2339: Property 'getActiveConnections' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(631,35): error TS2339: Property 'getConfiguration' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(644,22): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/mcp/skills/connection-monitoring.ts(676,20): error TS2339: Property 'emit' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { category: { type: string; description: string; required: false; }; tag: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; arguments: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(57,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(69,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; arguments: { type: string; description: string; required: false; }; context: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(91,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; arguments: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(108,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { template: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(120,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; template: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(137,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(149,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { name: { type: string; description: string; required: false; }; limit: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(174,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(182,36): error TS2339: Property 'getAvailablePrompts' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(186,34): error TS7006: Parameter 'prompt' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(190,34): error TS7006: Parameter 'prompt' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(196,32): error TS7006: Parameter 'prompt' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(207,47): error TS7006: Parameter 'p' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(208,45): error TS7006: Parameter 'p' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(234,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(241,38): error TS2339: Property 'getAvailablePrompts' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(242,35): error TS7006: Parameter 'p' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(253,43): error TS2339: Property 'validatePromptArguments' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(263,43): error TS2339: Property 'getPrompt' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(302,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(309,38): error TS2339: Property 'getAvailablePrompts' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(310,35): error TS7006: Parameter 'p' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(320,47): error TS2339: Property 'getPromptExecutionHistory' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(324,38): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(327,38): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(327,43): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(374,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(382,41): error TS2339: Property 'validatePromptArguments' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(391,43): error TS2339: Property 'executePrompt' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(395,22): error TS2339: Property 'logPromptExecution' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(441,41): error TS2339: Property 'validatePromptArguments' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(481,43): error TS2339: Property 'createPromptTemplate' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(513,43): error TS2339: Property 'updatePromptTemplate' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(545,43): error TS2339: Property 'deletePromptTemplate' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(570,36): error TS2339: Property 'getPromptExecutionHistory' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(580,35): error TS7006: Parameter 'execution' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(593,50): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(594,46): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(596,33): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/prompt-management.ts(596,38): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { type: { type: string; description: string; required: false; }; pattern: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { uri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(52,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { uri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(64,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { uri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(76,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { uri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(88,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { query: { type: string; description: string; required: true; }; type: { type: string; description: string; required: false; }; limit: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(110,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(116,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { uri: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(136,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(144,38): error TS2339: Property 'getAvailableResources' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(148,38): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(153,38): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(159,36): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(170,44): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(196,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(204,41): error TS2339: Property 'validateResourceUri' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(213,45): error TS2339: Property 'readResource' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(253,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(260,40): error TS2339: Property 'getAvailableResources' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(261,39): error TS7006: Parameter 'r' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(271,44): error TS2339: Property 'getResourceAccessHistory' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(278,35): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(278,40): error TS7006: Parameter 'a' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(325,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(332,43): error TS2339: Property 'subscribeToResource' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(365,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(372,43): error TS2339: Property 'unsubscribeFromResource' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(404,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(411,44): error TS2339: Property 'searchResources' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(417,32): error TS7006: Parameter 'result' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(443,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(450,40): error TS2339: Property 'getResourceTemplates' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(455,36): error TS7006: Parameter 'template' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/resource-access.ts(488,41): error TS2339: Property 'validateResourceUri' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { config: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(35,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { config: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(53,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { config: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(71,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(77,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(91,54): error TS2551: Property 'getConfig' does not exist on type 'McpExtension'. Did you mean 'config'?
+mind-agents/src/extensions/mcp/skills/server-management.ts(93,26): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(100,28): error TS2339: Property 'startServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(108,40): error TS2339: Property 'getServerCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(124,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(131,28): error TS2339: Property 'stopServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(152,54): error TS2551: Property 'getConfig' does not exist on type 'McpExtension'. Did you mean 'config'?
+mind-agents/src/extensions/mcp/skills/server-management.ts(154,26): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(155,30): error TS2339: Property 'stopServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(158,28): error TS2339: Property 'startServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(166,40): error TS2339: Property 'getServerCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(182,40): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(183,37): error TS2551: Property 'getConfig' does not exist on type 'McpExtension'. Did you mean 'config'?
+mind-agents/src/extensions/mcp/skills/server-management.ts(184,37): error TS2339: Property 'getServerUptime' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(197,40): error TS2339: Property 'getServerCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(198,33): error TS2339: Property 'getServerStats' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(223,41): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(226,30): error TS2339: Property 'stopServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(229,22): error TS2339: Property 'updateConfig' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(232,30): error TS2339: Property 'startServer' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(239,34): error TS2551: Property 'getConfig' does not exist on type 'McpExtension'. Did you mean 'config'?
+mind-agents/src/extensions/mcp/skills/server-management.ts(256,43): error TS2339: Property 'getServerCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(280,37): error TS2551: Property 'getConfig' does not exist on type 'McpExtension'. Did you mean 'config'?
+mind-agents/src/extensions/mcp/skills/server-management.ts(281,43): error TS2339: Property 'getServerCapabilities' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(282,36): error TS2339: Property 'getServerStats' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(283,37): error TS2339: Property 'getServerUptime' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(292,37): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(310,36): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/server-management.ts(312,38): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(9,10): error TS2305: Module '"../../../types/common.js"' has no exported member 'ActionResult'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolName: { type: string; description: string; required: true; }; parameters: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { category: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(52,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolName: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(64,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolName: { type: string; description: string; required: true; }; parameters: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(81,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolName: { type: string; description: string; required: false; }; limit: { type: string; description: string; required: false; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(98,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolDefinition: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(110,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { toolName: { type: string; description: string; required: true; }; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(139,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(147,45): error TS2339: Property 'getAvailableTools' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(148,40): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(153,87): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(158,41): error TS2339: Property 'validateToolParameters' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(168,43): error TS2339: Property 'executeTool' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(172,22): error TS2339: Property 'logToolExecution' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(206,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(213,36): error TS2339: Property 'getAvailableTools' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(218,38): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(227,36): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(236,45): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(261,27): error TS2339: Property 'isServerRunning' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(268,36): error TS2339: Property 'getAvailableTools' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(269,31): error TS7006: Parameter 't' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(279,47): error TS2339: Property 'getToolExecutionHistory' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(283,38): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(286,38): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(286,43): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(330,41): error TS2339: Property 'validateToolParameters' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(356,36): error TS2339: Property 'getToolExecutionHistory' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(366,35): error TS7006: Parameter 'execution' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(378,50): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(379,46): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(381,33): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(381,38): error TS7006: Parameter 'e' implicitly has an 'any' type.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(415,43): error TS2339: Property 'registerCustomTool' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/skills/tool-execution.ts(447,43): error TS2339: Property 'unregisterTool' does not exist on type 'McpExtension'.
+mind-agents/src/extensions/mcp/types.ts(7,27): error TS2307: Cannot find module '@modelcontextprotocol/sdk/server/mcp.js' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/types.ts(8,38): error TS2307: Cannot find module '@modelcontextprotocol/sdk/server/stdio.js' or its corresponding type declarations.
+mind-agents/src/extensions/mcp/types.ts(9,40): error TS2307: Cannot find module '@modelcontextprotocol/sdk/types.js' or its corresponding type declarations.
+mind-agents/src/extensions/runelite/index.ts(2,27): error TS2307: Cannot find module 'ws' or its corresponding type declarations.
+mind-agents/src/extensions/runelite/index.ts(3,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/extensions/runelite/index.ts(12,3): error TS2416: Property 'config' in type 'RuneLiteExtension' is not assignable to the same property in base type 'Extension'.
+  Type 'RuneLiteConfig' is missing the following properties from type 'ExtensionConfig': enabled, settings
+mind-agents/src/extensions/runelite/index.ts(50,31): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/extensions/runelite/index.ts(177,32): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/extensions/runelite/index.ts(193,30): error TS7006: Parameter 'error' implicitly has an 'any' type.
+mind-agents/src/extensions/runelite/index.ts(308,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(323,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { x: number; y: number; plane: number; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(325,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(331,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(346,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { targetId: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(348,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(354,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(370,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { targetId: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(372,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(378,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(394,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { spellName: string; targetId: string | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(396,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(402,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(418,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; targetId: string | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(420,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(426,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(441,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { message: string; type: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(443,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(449,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(464,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { action: string; itemId: string | undefined; quantity: number | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(466,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(472,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(488,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { playerId: string; action: string; items: any[] | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(490,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(496,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(512,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { skill: string; action: string; targetId: string | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/index.ts(514,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/banking.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; quantity: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/banking.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; quantity: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/banking.ts(49,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/banking.ts(66,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(79,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(85,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(99,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(113,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; quantity: number; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(119,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(133,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(147,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; quantity: number; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(153,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(167,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(181,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/banking.ts(187,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { targetId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/combat.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { spellName: string; targetId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/combat.ts(48,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(61,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { targetId: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(67,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(81,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(95,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { spellName: string; targetId: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/combat.ts(101,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { message: string; channel: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/communication.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { message: string; playerName: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/communication.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { message: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/communication.ts(57,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(70,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { message: string; channel: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(76,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(90,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(104,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { message: string; playerName: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(110,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(124,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(137,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { message: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/communication.ts(143,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(23,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(32,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(41,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { radius: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(50,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { radius: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(59,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { radius: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(68,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { radius: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(77,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { questName: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(94,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(106,9): error TS2322: Type 'GameState' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'GameState'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(110,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(124,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(137,9): error TS2322: Type 'Record<string, SkillData>' is not assignable to type 'GenericData'.
+  'string' index signatures are incompatible.
+    Type 'SkillData' is not assignable to type 'DataValue'.
+      Type 'SkillData' is not assignable to type 'GenericData'.
+        Index signature for type 'string' is missing in type 'SkillData'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(141,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(155,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(174,9): error TS2322: Type 'NPC[]' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'NPC[]'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(178,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(192,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(211,9): error TS2322: Type 'Player[]' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'Player[]'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(215,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(229,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(248,9): error TS2322: Type 'GameObject[]' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'GameObject[]'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(252,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(266,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(285,9): error TS2322: Type 'GroundItem[]' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'GroundItem[]'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(289,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(303,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(316,11): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(324,11): error TS2322: Type 'QuestData' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'QuestData'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(331,9): error TS2322: Type 'QuestData[]' is not assignable to type 'GenericData'.
+  Index signature for type 'string' is missing in type 'QuestData[]'.
+mind-agents/src/extensions/runelite/skills/gamestate.ts(335,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { targetId: string; action: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { skill: string; action: string; targetId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(48,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(62,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { targetId: string; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(68,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(82,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(96,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { skill: string; action: string; targetId: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/interaction.ts(102,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; targetId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(57,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(71,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; targetId: string | undefined; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(77,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(91,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(105,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(111,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(125,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(139,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/inventory.ts(145,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/movement.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { x: string; y: string; plane: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/movement.ts(39,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/movement.ts(53,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { x: number; y: number; plane: number; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/movement.ts(59,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(22,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { playerName: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/trading.ts(31,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { itemId: string; quantity: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/trading.ts(40,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { stage: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/trading.ts(49,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: {}; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/runelite/skills/trading.ts(66,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(80,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { playerName: string; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(86,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(100,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(114,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { itemId: string; quantity: number; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(120,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(135,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(149,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { stage: number; action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(155,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(169,9): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(183,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { action: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/runelite/skills/trading.ts(189,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(2,66): error TS2307: Cannot find module '@slack/bolt' or its corresponding type declarations.
+mind-agents/src/extensions/slack/index.ts(3,27): error TS2307: Cannot find module '@slack/web-api' or its corresponding type declarations.
+mind-agents/src/extensions/slack/index.ts(23,3): error TS2416: Property 'config' in type 'SlackExtension' is not assignable to the same property in base type 'Extension'.
+  Type 'SlackConfig' is missing the following properties from type 'ExtensionConfig': enabled, settings
+mind-agents/src/extensions/slack/index.ts(122,31): error TS7031: Binding element 'message' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(122,40): error TS7031: Binding element 'say' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(122,45): error TS7031: Binding element 'client' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(144,44): error TS7031: Binding element 'event' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(144,51): error TS7031: Binding element 'say' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(163,48): error TS7031: Binding element 'ack' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(163,53): error TS7031: Binding element 'body' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(163,59): error TS7031: Binding element 'client' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(168,47): error TS7031: Binding element 'ack' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(168,52): error TS7031: Binding element 'body' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(168,58): error TS7031: Binding element 'client' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(174,41): error TS7031: Binding element 'command' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(174,50): error TS7031: Binding element 'ack' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(174,55): error TS7031: Binding element 'respond' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(180,47): error TS7031: Binding element 'event' implicitly has an 'any' type.
+mind-agents/src/extensions/slack/index.ts(206,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: any; timestamp: any; message: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(215,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(293,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { approvalId: string; messageTs: any; timeout: number; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(302,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(329,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: any; timestamp: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(337,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(356,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: any; timestamp: any; thought: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(365,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(398,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(413,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; timestamp: string; emoji: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(418,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(434,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { status: string; emoji: string | undefined; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(439,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(454,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { scheduled_message_id: any; channel: string; post_at: number; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(463,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(763,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(768,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(778,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(783,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(793,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; topic: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(798,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(808,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; purpose: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(813,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(823,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(828,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(841,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(846,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(861,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(866,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(891,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(896,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(906,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(911,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(921,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { file: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(926,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(941,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(946,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(961,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(966,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(994,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(999,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1009,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1014,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1024,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1029,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1043,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { channel: any; timestamp: any; message: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1052,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1062,7): error TS2741: Property 'type' is missing in type '{ success: true; result: any; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1067,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1077,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { reminder: string; action: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1082,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1100,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { name: string; steps: any[]; channel: any; timestamp: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1110,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1133,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { task: string; assignee: string; dueDate: string; channel: any; timestamp: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1144,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1160,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { user: string; message: string; timestamp: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1169,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1187,11): error TS2322: Type 'UserPreferences | undefined' is not assignable to type 'DataValue'.
+  Type 'UserPreferences' is not assignable to type 'DataValue'.
+    Type 'UserPreferences' is not assignable to type 'GenericData'.
+      Index signature for type 'string' is missing in type 'UserPreferences'.
+mind-agents/src/extensions/slack/index.ts(1191,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1202,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { user: string; preferences: {}; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1210,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1223,7): error TS2741: Property 'type' is missing in type '{ success: true; result: { user: string; presence: any; online: any; auto_away: any; manual_away: any; connection_count: any; last_activity: any; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1236,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/index.ts(1395,31): error TS2307: Cannot find module 'fs/promises' or its corresponding type declarations.
+mind-agents/src/extensions/slack/index.ts(1396,39): error TS2580: Cannot find name 'Buffer'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/extensions/slack/skills/messaging.ts(104,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(121,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(138,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(155,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(172,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(189,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/messaging.ts(206,15): error TS2304: Cannot find name 'ActionResultType'.
+mind-agents/src/extensions/slack/skills/workflow.ts(112,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(128,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(144,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(160,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(176,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(192,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(208,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/slack/skills/workflow.ts(224,7): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/twitter/index.ts(9,42): error TS2307: Cannot find module 'puppeteer' or its corresponding type declarations.
+mind-agents/src/extensions/twitter/index.ts(22,3): error TS2416: Property 'config' in type 'TwitterExtension' is not assignable to the same property in base type 'Extension'.
+  Type 'TwitterConfig' is missing the following properties from type 'ExtensionConfig': enabled, settings
+mind-agents/src/extensions/twitter/index.ts(408,5): error TS2741: Property 'type' is missing in type '{ success: true; result: { userId: string; users: never[]; count: number; nextToken: string | undefined; timestamp: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/twitter/index.ts(417,5): error TS2741: Property 'type' is missing in type '{ success: true; result: { userId: string; users: never[]; count: number; nextToken: string | undefined; timestamp: string; }; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/twitter/skills/base-skill.ts(41,5): error TS2741: Property 'type' is missing in type '{ success: false; error: string; metadata: { timestamp: string; errorType: TwitterErrorType; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/twitter/skills/base-skill.ts(55,5): error TS2741: Property 'type' is missing in type '{ success: true; result: any; metadata: { timestamp: string; }; }' but required in type 'ActionResult'.
+mind-agents/src/extensions/twitter/skills/engagement.ts(79,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.QUOTE; description: string; parameters: { tweet_id: string; text: string; media_ids: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.QUOTE; description: string; parameters: { tweet_id: string; text: string; media_ids: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/index.ts(22,3): error TS1205: Re-exporting a type when 'isolatedModules' is enabled requires using 'export type'.
+mind-agents/src/extensions/twitter/skills/media.ts(18,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.UPLOAD_MEDIA; description: string; parameters: { file_path: string; alt_text: string; media_type: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.UPLOAD_MEDIA; description: string; parameters: { file_path: string; alt_text: string; media_type: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/media.ts(35,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.DELETE_MEDIA; description: string; parameters: { media_key: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.DELETE_MEDIA; description: string; parameters: { media_key: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/search.ts(18,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.SEARCH_TWEETS; description: string; parameters: { query: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.SEARCH_TWEETS; description: string; parameters: { query: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/search.ts(31,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.SEARCH_USERS; description: string; parameters: { query: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.SEARCH_USERS; description: string; parameters: { query: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/search.ts(44,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.SEARCH_TRENDING; description: string; parameters: { woeid: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.SEARCH_TRENDING; description: string; parameters: { woeid: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(18,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.FOLLOW; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.FOLLOW; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(29,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.UNFOLLOW; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.UNFOLLOW; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(40,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.BLOCK; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.BLOCK; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(51,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.UNBLOCK; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.UNBLOCK; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(62,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.MUTE; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.MUTE; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(73,7): error TS2418: Type of computed property's value is '{ name: TwitterActionType.UNMUTE; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }', which is not assignable to type 'ExtensionAction'.
+  Property 'category' is missing in type '{ name: TwitterActionType.UNMUTE; description: string; parameters: { user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(84,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { username: string; user_id: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(96,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { user_id: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/extensions/twitter/skills/user-management.ts(109,7): error TS2741: Property 'category' is missing in type '{ name: string; description: string; parameters: { user_id: string; max_results: string; next_token: string; }; execute: (agent: Agent, params: any) => Promise<ActionResult>; }' but required in type 'ExtensionAction'.
+mind-agents/src/index.ts(1,20): error TS2307: Cannot find module 'dotenv' or its corresponding type declarations.
+mind-agents/src/index.ts(2,18): error TS2307: Cannot find module 'path' or its corresponding type declarations.
+mind-agents/src/index.ts(3,31): error TS2307: Cannot find module 'url' or its corresponding type declarations.
+mind-agents/src/index.ts(32,15): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(33,18): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(34,13): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(35,12): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(36,19): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(37,21): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(60,5): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(67,1): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(71,3): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(74,1): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/index.ts(78,3): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/lib/math.test.ts(3,1): error TS2582: Cannot find name 'describe'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
+mind-agents/src/lib/math.test.ts(4,3): error TS2582: Cannot find name 'it'. Do you need to install type definitions for a test runner? Try `npm i --save-dev @types/jest` or `npm i --save-dev @types/mocha`.
+mind-agents/src/lib/math.test.ts(5,5): error TS2304: Cannot find name 'expect'.
+mind-agents/src/lib/utils.ts(1,39): error TS2307: Cannot find module 'clsx' or its corresponding type declarations.
+mind-agents/src/lib/utils.ts(2,25): error TS2307: Cannot find module 'tailwind-merge' or its corresponding type declarations.
+mind-agents/src/modules/coordination/index.ts(8,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/modules/coordination/index.ts(618,31): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/index.ts(7,38): error TS2307: Cannot find module './memory/providers/index.js' or its corresponding type declarations.
+mind-agents/src/modules/observability/index.ts(8,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/modules/observability/index.ts(502,24): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/observability/index.ts(601,12): error TS2339: Property 'emit' does not exist on type 'SYMindXHealthMonitor'.
+mind-agents/src/modules/observability/index.ts(613,10): error TS2339: Property 'on' does not exist on type 'SYMindXHealthMonitor'.
+mind-agents/src/modules/observability/index.ts(639,10): error TS2339: Property 'removeAllListeners' does not exist on type 'SYMindXHealthMonitor'.
+mind-agents/src/modules/observability/index.ts(687,23): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/observability/index.ts(718,31): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/observability/index.ts(738,25): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/observability/index.ts(739,11): error TS2304: Cannot find name 'setImmediate'.
+mind-agents/src/modules/observability/index.ts(740,32): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/streaming/index.ts(8,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/modules/streaming/index.ts(449,25): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/tools/index.ts(8,37): error TS2307: Cannot find module 'child_process' or its corresponding type declarations.
+mind-agents/src/modules/tools/index.ts(9,32): error TS2307: Cannot find module 'fs' or its corresponding type declarations.
+mind-agents/src/modules/tools/index.ts(10,31): error TS2307: Cannot find module 'path' or its corresponding type declarations.
+mind-agents/src/modules/tools/index.ts(11,24): error TS2307: Cannot find module 'os' or its corresponding type declarations.
+mind-agents/src/modules/tools/index.ts(12,30): error TS2307: Cannot find module 'events' or its corresponding type declarations.
+mind-agents/src/modules/tools/index.ts(95,27): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(188,53): error TS2345: Argument of type 'string | undefined' is not assignable to parameter of type 'string'.
+  Type 'undefined' is not assignable to type 'string'.
+mind-agents/src/modules/tools/index.ts(211,24): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(282,24): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(462,14): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(473,33): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(477,33): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(498,26): error TS7006: Parameter 'code' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(540,26): error TS7006: Parameter 'error' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(606,24): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(703,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(715,25): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/tools/index.ts(727,33): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(730,14): error TS2339: Property 'emit' does not exist on type 'SYMindXTerminalInterface'.
+mind-agents/src/modules/tools/index.ts(733,33): error TS7006: Parameter 'data' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(736,14): error TS2339: Property 'emit' does not exist on type 'SYMindXTerminalInterface'.
+mind-agents/src/modules/tools/index.ts(752,26): error TS7006: Parameter 'code' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(767,14): error TS2339: Property 'emit' does not exist on type 'SYMindXTerminalInterface'.
+mind-agents/src/modules/tools/index.ts(771,26): error TS7006: Parameter 'error' implicitly has an 'any' type.
+mind-agents/src/modules/tools/index.ts(786,14): error TS2339: Property 'emit' does not exist on type 'SYMindXTerminalInterface'.
+mind-agents/src/modules/tools/index.ts(801,27): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/modules/tools/index.ts(814,23): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/tools/index.ts(828,42): error TS2503: Cannot find namespace 'NodeJS'.
+mind-agents/src/modules/tools/index.ts(850,12): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/anthropic/index.ts(8,44): error TS2307: Cannot find module '@ai-sdk/anthropic' or its corresponding type declarations.
+mind-agents/src/portals/anthropic/index.ts(9,42): error TS2307: Cannot find module 'ai' or its corresponding type declarations.
+mind-agents/src/portals/anthropic/index.ts(38,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/anthropic/index.ts(39,9): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/groq/index.ts(8,34): error TS2307: Cannot find module '@ai-sdk/groq' or its corresponding type declarations.
+mind-agents/src/portals/groq/index.ts(9,42): error TS2307: Cannot find module 'ai' or its corresponding type declarations.
+mind-agents/src/portals/groq/index.ts(38,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/groq/index.ts(39,9): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/integration.ts(33,40): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/openai/index.ts(8,38): error TS2307: Cannot find module '@ai-sdk/openai' or its corresponding type declarations.
+mind-agents/src/portals/openai/index.ts(9,42): error TS2307: Cannot find module 'ai' or its corresponding type declarations.
+mind-agents/src/portals/openai/index.ts(43,29): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+mind-agents/src/portals/openai/index.ts(44,9): error TS2580: Cannot find name 'process'. Do you need to install type definitions for node? Try `npm i --save-dev @types/node`.
+website/src/App.tsx(1,37): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/App.tsx(6,58): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/App.tsx(92,19): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/App.tsx(92,36): error TS7006: Parameter 'agent' implicitly has an 'any' type.
+website/src/App.tsx(124,15): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/App.tsx(124,32): error TS7006: Parameter 'agent' implicitly has an 'any' type.
+website/src/App.tsx(132,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(132,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/App.tsx(133,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(134,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(135,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(137,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(137,69): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(138,14): error TS2322: Type '{ children: string[]; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(141,14): error TS2322: Type '{ children: string[]; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(144,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(145,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(147,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(149,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(154,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(154,31): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(162,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(164,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(164,43): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(165,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(165,83): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(166,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(168,30): error TS7006: Parameter 'agent' implicitly has an 'any' type.
+website/src/App.tsx(169,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(170,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(171,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(180,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(183,45): error TS7006: Parameter 'checked' implicitly has an 'any' type.
+website/src/App.tsx(185,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(186,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(187,26): error TS2322: Type '{ children: any; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(190,26): error TS2322: Type '{ children: any; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(191,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(192,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(193,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(194,49): error TS7006: Parameter 'ext' implicitly has an 'any' type.
+website/src/App.tsx(195,30): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(199,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(201,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(202,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(202,81): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(203,51): error TS7006: Parameter 'server' implicitly has an 'any' type.
+website/src/App.tsx(204,32): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(208,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(211,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(212,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(212,90): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(213,53): error TS7006: Parameter 'cap' implicitly has an 'any' type.
+website/src/App.tsx(214,32): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(218,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(221,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(222,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(222,71): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(223,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(223,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(224,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(224,87): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(225,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(227,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(228,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(233,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(236,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(242,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(242,33): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(246,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(246,33): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(286,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(292,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(293,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(294,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(295,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(295,47): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(296,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(296,48): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/App.tsx(296,105): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(297,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(298,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(299,29): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(301,62): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/App.tsx(303,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(304,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(305,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(306,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(306,67): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(307,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(307,76): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/App.tsx(307,135): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(308,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(309,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(310,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(310,58): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(311,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(311,77): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/App.tsx(311,141): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(312,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(313,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(322,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(323,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(324,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(324,63): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(325,28): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(326,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(327,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(328,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(328,59): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(329,28): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(330,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(331,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(332,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(332,63): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(333,28): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(334,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(335,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(336,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(336,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(337,28): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/App.tsx(338,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(339,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(348,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(349,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(350,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(350,46): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(351,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(351,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(352,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(353,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(354,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(354,46): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(355,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(355,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(356,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(357,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(358,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(358,41): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(359,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(359,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(360,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(361,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(362,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(362,47): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(363,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(363,74): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(364,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(365,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(368,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(383,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(384,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(385,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/App.tsx(386,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(1,26): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/AgentControls.tsx(5,106): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/AgentControls.tsx(40,7): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/AgentControls.tsx(42,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(44,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(44,35): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(45,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(45,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(46,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(53,24): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/AgentControls.tsx(87,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(93,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(93,31): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(100,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(101,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(102,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(102,58): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(103,16): error TS2322: Type '{ children: "active"; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/AgentControls.tsx(106,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(107,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(108,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(108,59): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(109,16): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/AgentControls.tsx(110,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(111,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(113,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(114,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(114,67): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(115,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(117,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(118,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(120,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(121,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(126,48): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(126,59): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(128,47): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(128,59): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(130,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(131,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(136,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(136,26): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(137,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(138,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(152,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(153,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(155,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(156,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(156,88): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(157,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(164,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(165,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(166,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(171,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(185,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(186,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(187,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(187,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(188,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(188,61): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(189,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(190,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(195,26): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/AgentControls.tsx(198,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(199,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(199,26): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(200,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(200,52): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(201,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(201,53): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(202,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(203,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(207,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(208,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(222,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(223,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(224,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(224,89): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(225,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(225,55): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(226,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(227,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(232,28): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/AgentControls.tsx(232,55): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/AgentControls.tsx(238,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(252,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(253,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(254,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(254,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(255,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(255,80): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(256,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(257,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(258,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(258,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(259,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(259,86): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(260,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(261,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(262,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(262,66): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(263,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(263,78): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(264,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(265,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(266,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(266,62): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(267,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(267,84): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(268,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(269,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(270,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(270,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(271,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(271,83): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(272,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(273,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(274,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(274,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(275,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(275,87): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(276,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(277,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(278,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(278,66): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(279,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(279,84): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(280,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(281,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(282,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(282,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(283,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(283,84): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(284,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(285,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/AgentControls.tsx(288,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(1,52): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/Chat.tsx(7,57): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/Chat.tsx(82,17): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/Chat.tsx(109,23): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/Chat.tsx(120,21): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/Chat.tsx(131,19): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/Chat.tsx(147,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(147,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/Chat.tsx(153,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(153,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(160,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(161,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(162,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(170,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(171,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(171,45): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(172,28): error TS2322: Type '{ children: "active" | "error" | "idle" | "thinking" | "paused"; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/Chat.tsx(175,28): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/Chat.tsx(176,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(181,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(183,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(185,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(185,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(186,20): error TS2322: Type '{ children: "active" | "error" | "idle" | "thinking" | "paused"; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/Chat.tsx(189,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(191,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(192,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(202,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(202,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(204,18): error TS2322: Type '{ children: "active" | "error" | "idle" | "thinking" | "paused"; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/Chat.tsx(213,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(215,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(217,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(217,37): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(218,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(218,93): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(219,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(221,30): error TS7006: Parameter 'message' implicitly has an 'any' type.
+website/src/components/Chat.tsx(222,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(228,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(238,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(239,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(242,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(247,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(247,77): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(248,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(249,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(251,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(252,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(253,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(257,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(258,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(260,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(261,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(262,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(263,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(265,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(265,42): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(266,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(267,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(268,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(269,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(271,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(272,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(275,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(278,28): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/Chat.tsx(295,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(298,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(300,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/Chat.tsx(305,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(1,33): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/CoordinationDashboard.tsx(5,85): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/CoordinationDashboard.tsx(130,13): error TS2322: Type '{ children: "active" | "idle" | "busy"; variant: "default" | "outline" | "secondary"; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(140,13): error TS2322: Type '{ children: "low" | "medium" | "high"; variant: "default" | "secondary" | "destructive"; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(153,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(153,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/CoordinationDashboard.tsx(159,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(159,32): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(166,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(167,25): error TS7006: Parameter 'agent' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(168,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(169,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(170,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(170,60): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(172,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(174,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(175,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(176,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(176,72): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(177,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(178,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(179,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(183,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(184,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(184,62): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(185,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(186,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(188,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(189,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(189,85): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(190,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(191,47): error TS7006: Parameter 'cap' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(192,26): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(196,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(197,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(200,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(201,44): error TS7006: Parameter 't' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(202,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(204,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(205,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(207,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(212,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(221,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(222,26): error TS7006: Parameter 'task' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(223,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(224,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(225,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(227,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(227,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(228,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(230,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(232,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(233,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(234,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(234,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(235,24): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(236,38): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(238,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(240,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(241,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(241,32): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(242,24): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(243,38): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(245,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(246,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(248,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(249,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(249,58): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(251,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(251,57): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(253,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(254,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(256,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(264,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(264,46): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(271,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(272,29): error TS7006: Parameter 'message' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(273,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(274,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(275,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(276,24): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(277,38): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(280,24): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/CoordinationDashboard.tsx(281,38): error TS7006: Parameter 'a' implicitly has an 'any' type.
+website/src/components/CoordinationDashboard.tsx(283,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(284,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(286,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(287,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(288,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(288,61): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(289,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(291,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(294,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(305,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(308,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(308,54): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(312,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(312,53): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(316,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(316,53): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(320,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(320,55): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(322,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/CoordinationDashboard.tsx(325,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(1,33): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/DynamicToolsDashboard.tsx(5,96): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/DynamicToolsDashboard.tsx(144,13): error TS2322: Type '{ children: "active" | "error" | "inactive" | "testing"; variant: "default" | "outline" | "secondary" | "destructive"; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/DynamicToolsDashboard.tsx(170,14): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(170,31): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(180,14): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(180,34): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(186,36): error TS7006: Parameter 't' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(187,36): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(187,41): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(188,40): error TS7006: Parameter 'sum' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(188,45): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(191,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(191,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/DynamicToolsDashboard.tsx(196,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(198,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(198,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(199,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(210,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(211,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(212,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(212,79): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(213,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(213,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(214,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(215,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(216,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(216,79): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(217,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(217,68): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(218,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(219,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(220,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(220,79): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(221,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(221,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(222,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(223,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(224,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(224,95): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(225,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(225,78): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(226,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(227,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(232,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(241,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(242,26): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(243,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(250,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(251,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(252,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(252,81): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(253,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(253,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(254,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(255,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(258,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(259,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(261,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(263,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(265,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(266,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(266,55): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(267,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(267,88): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(268,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(270,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(271,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(271,93): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(272,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(272,93): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(273,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(274,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(276,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(290,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(292,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(293,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(294,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(294,68): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(295,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(316,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(317,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(318,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(318,90): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(319,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(322,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(323,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(323,62): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(324,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(325,50): error TS7006: Parameter 'param' implicitly has an 'any' type.
+website/src/components/DynamicToolsDashboard.tsx(326,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(327,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(328,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(328,79): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(329,28): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/DynamicToolsDashboard.tsx(330,47): error TS2322: Type '{ children: string; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/DynamicToolsDashboard.tsx(331,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(332,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(332,83): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(334,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(335,38): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(335,80): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(336,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(338,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(340,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(341,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(344,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(345,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(345,63): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(346,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(347,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(348,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(348,112): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(349,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(349,82): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(350,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(351,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(352,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(352,116): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(353,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(353,78): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(354,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(355,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(356,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(356,108): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(357,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(357,76): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(358,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(359,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(360,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(363,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(364,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(366,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(366,31): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(367,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(368,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(369,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(369,45): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(370,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(371,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(372,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(374,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(376,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(380,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(391,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(394,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(394,52): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(398,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(398,52): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(402,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(402,49): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(406,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(406,49): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(408,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/DynamicToolsDashboard.tsx(411,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(1,44): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/EmotionGraph.tsx(4,56): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/EmotionGraph.tsx(63,33): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/EmotionGraph.tsx(98,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(98,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/EmotionGraph.tsx(104,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(104,42): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(112,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(113,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(114,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(115,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(118,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(119,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(119,89): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(120,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(122,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(123,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(124,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(126,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(127,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(128,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(128,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(129,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(129,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(130,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(131,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(132,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(136,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(137,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(139,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(140,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(140,66): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(141,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(142,49): error TS7006: Parameter 'trigger' implicitly has an 'any' type.
+website/src/components/EmotionGraph.tsx(142,58): error TS7006: Parameter 'index' implicitly has an 'any' type.
+website/src/components/EmotionGraph.tsx(143,22): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/EmotionGraph.tsx(147,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(148,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(149,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(152,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(154,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(156,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(157,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(158,26): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(159,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(160,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(161,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(170,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(170,35): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(177,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(179,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(181,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(183,54): error TS7006: Parameter 'emotion' implicitly has an 'any' type.
+website/src/components/EmotionGraph.tsx(183,63): error TS7006: Parameter 'index' implicitly has an 'any' type.
+website/src/components/EmotionGraph.tsx(186,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(187,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(188,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(189,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(190,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(190,81): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(191,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(193,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(194,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(195,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(196,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(197,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(201,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(202,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(204,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(205,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(206,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(207,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(210,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(223,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(225,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(226,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(227,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(228,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(228,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(229,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(229,87): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(230,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(231,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(233,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/EmotionGraph.tsx(236,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(1,44): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/McpServerManager.tsx(8,99): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/McpServerManager.tsx(104,13): error TS2322: Type '{ children: "error" | "connected" | "disconnected" | "connecting"; variant: "default" | "outline" | "secondary" | "destructive"; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/McpServerManager.tsx(122,20): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(122,37): error TS7006: Parameter 'server' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(148,20): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(148,37): error TS7006: Parameter 'server' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(239,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(239,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/McpServerManager.tsx(244,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(244,37): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(252,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(254,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(256,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(258,26): error TS7006: Parameter 'server' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(259,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(260,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(261,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(263,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(264,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(264,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(265,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(267,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(268,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(269,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(270,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(291,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(292,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(296,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(297,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(298,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(298,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(299,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(300,41): error TS7006: Parameter 'tool' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(301,26): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/McpServerManager.tsx(305,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(306,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(307,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(308,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(308,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(309,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(310,45): error TS7006: Parameter 'resource' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(311,26): error TS2322: Type '{ children: any; key: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/McpServerManager.tsx(315,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(316,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(317,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(319,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(321,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(322,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(324,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(336,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(337,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(338,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(345,30): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(345,49): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(347,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(348,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(350,123): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(360,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(361,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(362,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(369,28): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(369,47): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/McpServerManager.tsx(371,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(380,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/McpServerManager.tsx(383,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(1,45): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/StreamCanvas.tsx(5,61): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/StreamCanvas.tsx(48,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(48,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/StreamCanvas.tsx(54,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(54,34): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(61,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(62,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(68,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(70,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(71,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(72,14): error TS2322: Type '{ children: string; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/StreamCanvas.tsx(75,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(77,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(78,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(78,66): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(83,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(85,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(86,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(86,62): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(87,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(90,26): error TS7006: Parameter 'e' implicitly has an 'any' type.
+website/src/components/StreamCanvas.tsx(94,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(102,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(104,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(104,32): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(105,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(106,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(107,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(113,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(115,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(122,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(129,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(140,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(142,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(143,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(144,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(145,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(145,73): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(146,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(147,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(148,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(148,46): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(149,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(149,52): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(150,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(150,50): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(151,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(152,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(155,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(156,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(156,80): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(157,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(159,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(160,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(163,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(164,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(164,77): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(165,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(166,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(167,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(168,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(168,45): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(169,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(170,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(171,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(172,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(172,46): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(173,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(174,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(175,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(176,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(176,48): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(177,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(178,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(179,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(182,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(183,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(183,76): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(184,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(185,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(185,37): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(186,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(186,43): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(187,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(187,45): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(188,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(189,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(190,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(194,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(195,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(197,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(197,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(198,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(200,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(201,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(203,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(204,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(205,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(207,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(220,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(221,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(222,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(222,54): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(223,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(223,63): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(224,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(225,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(226,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(226,50): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(227,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(227,59): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(228,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(229,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(230,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(230,53): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(231,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(231,60): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(232,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(233,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(234,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(234,51): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(235,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(235,60): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(236,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(237,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(239,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(240,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(240,69): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(241,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(242,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(242,57): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(243,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(243,60): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(244,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(244,57): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(245,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(245,54): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(246,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(247,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamCanvas.tsx(250,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(1,44): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/StreamingDashboard.tsx(5,67): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/StreamingDashboard.tsx(93,17): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/StreamingDashboard.tsx(96,18): error TS7006: Parameter 'prev' implicitly has an 'any' type.
+website/src/components/StreamingDashboard.tsx(142,40): error TS7006: Parameter 'event' implicitly has an 'any' type.
+website/src/components/StreamingDashboard.tsx(154,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(154,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/StreamingDashboard.tsx(159,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(161,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(161,37): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(163,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(164,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(165,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(165,64): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(166,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(168,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(169,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(182,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(190,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(191,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(192,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(192,101): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(193,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(193,72): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(194,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(195,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(196,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(196,87): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(197,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(197,74): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(198,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(199,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(200,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(200,90): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(201,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(201,76): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(202,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(203,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(204,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(204,99): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(205,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(205,68): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(206,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(207,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(208,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(208,94): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(209,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(209,69): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(210,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(211,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(214,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(223,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(223,83): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(227,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(236,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(236,31): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(237,14): error TS2322: Type '{ children: any[]; variant: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/StreamingDashboard.tsx(241,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(243,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(245,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(247,34): error TS7006: Parameter 'event' implicitly has an 'any' type.
+website/src/components/StreamingDashboard.tsx(248,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(252,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(253,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(254,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(254,75): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(255,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(256,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(257,28): error TS2322: Type '{ children: any; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/StreamingDashboard.tsx(260,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(262,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(264,30): error TS2322: Type '{ children: string; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/StreamingDashboard.tsx(268,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(269,25): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(269,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(271,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(273,27): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(275,23): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(276,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(277,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(278,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(281,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(290,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(290,39): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(297,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(298,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(299,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(299,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(300,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(301,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(308,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(308,67): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(309,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(310,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(311,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(312,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(312,70): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(313,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(314,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(314,51): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(315,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(315,50): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(316,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(316,51): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(317,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(317,53): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(318,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(319,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(320,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(321,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(321,65): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(322,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(323,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(324,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(324,63): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(325,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(326,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(327,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/StreamingDashboard.tsx(330,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(1,52): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ThoughtStream.tsx(4,41): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/ThoughtStream.tsx(88,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ThoughtStream.tsx(92,11): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(92,31): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(100,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(105,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(107,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(109,26): error TS7006: Parameter 'thought' implicitly has an 'any' type.
+website/src/components/ThoughtStream.tsx(110,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(111,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(111,67): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(112,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(113,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(114,20): error TS2322: Type '{ children: any; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/ThoughtStream.tsx(117,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(119,21): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(119,67): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(120,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(121,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(122,17): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(122,57): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(124,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(126,24): error TS2322: Type '{ children: string[]; key: string; variant: string; className: string; }' is not assignable to type 'BadgeProps'.
+  Property 'children' does not exist on type 'BadgeProps'.
+website/src/components/ThoughtStream.tsx(130,19): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(132,15): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(133,13): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ThoughtStream.tsx(135,9): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/badge.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/badge.tsx(2,40): error TS2307: Cannot find module 'class-variance-authority' or its corresponding type declarations.
+website/src/components/ui/badge.tsx(30,18): error TS2339: Property 'className' does not exist on type 'BadgeProps'.
+website/src/components/ui/badge.tsx(30,29): error TS2339: Property 'variant' does not exist on type 'BadgeProps'.
+website/src/components/ui/badge.tsx(32,5): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/badge.tsx(32,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/button.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/button.tsx(2,22): error TS2307: Cannot find module '@radix-ui/react-slot' or its corresponding type declarations.
+website/src/components/ui/button.tsx(3,40): error TS2307: Cannot find module 'class-variance-authority' or its corresponding type declarations.
+website/src/components/ui/button.tsx(43,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/button.tsx(43,17): error TS7031: Binding element 'variant' implicitly has an 'any' type.
+website/src/components/ui/button.tsx(43,26): error TS7031: Binding element 'size' implicitly has an 'any' type.
+website/src/components/ui/button.tsx(43,61): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/button.tsx(46,7): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/card.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/card.tsx(8,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(8,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(9,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/card.tsx(9,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/card.tsx(23,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(23,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(24,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/card.tsx(31,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(31,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(32,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/card.tsx(46,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(46,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(47,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/card.tsx(58,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(58,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(59,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/card.tsx(66,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(66,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/card.tsx(67,3): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/input.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/input.tsx(9,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/input.tsx(9,17): error TS7031: Binding element 'type' implicitly has an 'any' type.
+website/src/components/ui/input.tsx(9,35): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/input.tsx(11,7): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/input.tsx(11,7): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/label.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/label.tsx(2,33): error TS2307: Cannot find module '@radix-ui/react-label' or its corresponding type declarations.
+website/src/components/ui/label.tsx(3,40): error TS2307: Cannot find module 'class-variance-authority' or its corresponding type declarations.
+website/src/components/ui/label.tsx(15,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/label.tsx(15,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/label.tsx(16,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/select.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/select.tsx(2,34): error TS2307: Cannot find module '@radix-ui/react-select' or its corresponding type declarations.
+website/src/components/ui/select.tsx(3,47): error TS2307: Cannot find module 'lucide-react' or its corresponding type declarations.
+website/src/components/ui/select.tsx(16,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(16,17): error TS7031: Binding element 'children' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(16,39): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(17,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/select.tsx(36,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(36,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(53,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(53,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(71,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(71,17): error TS7031: Binding element 'children' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(71,60): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(103,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(103,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(115,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(115,17): error TS7031: Binding element 'children' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(115,39): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(124,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/select.tsx(128,5): error TS7026: JSX element implicitly has type 'any' because no interface 'JSX.IntrinsicElements' exists.
+website/src/components/ui/select.tsx(138,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/select.tsx(138,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/switch.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/switch.tsx(2,35): error TS2307: Cannot find module '@radix-ui/react-switch' or its corresponding type declarations.
+website/src/components/ui/switch.tsx(9,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/switch.tsx(9,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/switch.tsx(10,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/tabs.tsx(1,24): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/components/ui/tabs.tsx(2,32): error TS2307: Cannot find module '@radix-ui/react-tabs' or its corresponding type declarations.
+website/src/components/ui/tabs.tsx(11,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/tabs.tsx(11,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/tabs.tsx(12,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.
+website/src/components/ui/tabs.tsx(26,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/tabs.tsx(26,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/components/ui/tabs.tsx(41,6): error TS7031: Binding element 'className' implicitly has an 'any' type.
+website/src/components/ui/tabs.tsx(41,29): error TS7006: Parameter 'ref' implicitly has an 'any' type.
+website/src/lib/utils.ts(1,39): error TS2307: Cannot find module 'clsx' or its corresponding type declarations.
+website/src/lib/utils.ts(2,25): error TS2307: Cannot find module 'tailwind-merge' or its corresponding type declarations.
+website/src/main.tsx(1,19): error TS2307: Cannot find module 'react' or its corresponding type declarations.
+website/src/main.tsx(2,22): error TS2307: Cannot find module 'react-dom/client' or its corresponding type declarations.
+website/src/main.tsx(7,3): error TS2875: This JSX tag requires the module path 'react/jsx-runtime' to exist, but none could be found. Make sure you have types for the appropriate package installed.


### PR DESCRIPTION
## Summary
- run TypeScript type checks for `mind-agents` and `website`
- capture all output in **type-check-results.md** for reference

## Testing
- `bun run test`

------
https://chatgpt.com/codex/tasks/task_e_68474ce0721883309b678803a02a4a32