### PR TITLE
Improve runtime status fetching

### DIFF
--- a/mind-agents/src/core/registry.ts
+++ b/mind-agents/src/core/registry.ts
@@ -92,6 +92,18 @@ export class SYMindXModuleRegistry implements ModuleRegistry {
     return Array.from(this.portals.keys())
   }
 
+  listMemoryProviders(): string[] {
+    return Array.from(this.memoryProviders.keys())
+  }
+
+  listEmotionModules(): string[] {
+    return Array.from(this.emotionModules.keys())
+  }
+
+  listCognitionModules(): string[] {
+    return Array.from(this.cognitionModules.keys())
+  }
+
   // Tool system methods
   registerToolSystem(name: string, toolSystem: ToolSystem): void {
     if (!name || !toolSystem) {

--- a/mind-agents/src/types/agent.ts
+++ b/mind-agents/src/types/agent.ts
@@ -488,6 +488,10 @@ export interface ModuleRegistry {
   getCognitionModule(name: string): CognitionModule | undefined
   getExtension(name: string): Extension | undefined
   getPortal(name: string): Portal | undefined
+  listMemoryProviders(): string[]
+  listEmotionModules(): string[]
+  listCognitionModules(): string[]
+  listPortals(): string[]
 }
 
 export enum LogLevel {


### PR DESCRIPTION
### **User description**
## Summary
- expose listing methods for modules in the registry
- provide these methods in the `ModuleRegistry` interface
- load runtime version from `package.json` and show available plugins
- list registered memory providers when reporting runtime status

## Testing
- `bun test` *(fails: jest.mock is not a function)*
- `npm test` *(fails: ts-node is required)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecb28ffc8330b26eddd2e6e7e13c


___

### **PR Type**
Enhancement


___

### **Description**
- Add listing methods for registry modules (memory, emotion, cognition)

- Implement dynamic runtime status fetching with version from package.json

- Expose available plugins in runtime status

- Update ModuleRegistry interface with new listing methods


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>registry.ts</strong><dd><code>Add registry module listing methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mind-agents/src/core/registry.ts

<li>Add <code>listMemoryProviders()</code> method to return registered memory provider <br>names<br> <li> Add <code>listEmotionModules()</code> method to return registered emotion module <br>names  <br> <li> Add <code>listCognitionModules()</code> method to return registered cognition <br>module names


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/SYMindX/pull/8/files#diff-aedc5d17c7e9aa463fd349a5e3b17e16318c3ecfebaf7ea0098392c22fc4d5a9">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>runtime.ts</strong><dd><code>Implement dynamic runtime status fetching</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mind-agents/src/core/runtime.ts

<li>Rename <code>getRuntimeCapabilities()</code> to <code>getStatus()</code> and make it async<br> <li> Read runtime version dynamically from <code>package.json</code> file<br> <li> Fetch available plugins list and include in status response<br> <li> Use registry listing methods for dynamic memory providers


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/SYMindX/pull/8/files#diff-a5eb414f7af298b72ab2a964abd65e9f25725c8eafd2c94792625f61e31ca158">+22/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>agent.ts</strong><dd><code>Update ModuleRegistry interface with listing methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

mind-agents/src/types/agent.ts

<li>Add <code>listMemoryProviders()</code> method signature to ModuleRegistry interface<br> <li> Add <code>listEmotionModules()</code> method signature to ModuleRegistry interface<br> <li> Add <code>listCognitionModules()</code> method signature to ModuleRegistry <br>interface<br> <li> Add <code>listPortals()</code> method signature to ModuleRegistry interface


</details>


  </td>
  <td><a href="https://github.com/Dexploarer/SYMindX/pull/8/files#diff-cf931aff31ac3eabb4caf81f675f87f5aa7ebe6013c1bd817cec493e010e4ceb">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>