### PR TITLE
Fix terminal type in code executor

### DIFF
--- a/mind-agents/src/modules/tools/index.ts
+++ b/mind-agents/src/modules/tools/index.ts
@@ -121,8 +121,8 @@ export class SYMindXDynamicToolSystem implements DynamicToolSystem {
       ...config
     }
 
-    this.codeExecution = new SYMindXCodeExecutor(this.config)
     this.terminalAccess = new SYMindXTerminalInterface(this.config)
+    this.codeExecution = new SYMindXCodeExecutor(this.config, this.terminalAccess)
   }
 
   createTool(specification: ToolSpec): ToolSpec {

--- a/mind-agents/src/modules/tools/logic/CodeExecutor.ts
+++ b/mind-agents/src/modules/tools/logic/CodeExecutor.ts
@@ -94,7 +94,7 @@ export class SYMindXCodeExecutor extends EventEmitter implements ICodeExecutor {
    * Creates a new instance of SYMindXCodeExecutor
    * 
    * @param {ToolSystemConfig} config - Configuration for the code executor
-   * @param {any} terminal - Terminal interface for command execution (TODO: Replace with ITerminalInterface)
+   * @param {ITerminalInterface} terminal - Terminal interface for command execution
    * @param {Logger} [logger] - Optional logger instance. If not provided, a new one will be created.
    * 
    * @example


### PR DESCRIPTION
## Summary
- use `ITerminalInterface` in `SYMindXCodeExecutor` JSDoc and constructor
- pass a terminal instance when constructing the executor in the tool system

## Testing
- `bun test` *(fails: needs bun install)*

------
https://chatgpt.com/codex/tasks/task_e_6857ecb418e88330bcdeb3b5176b2934